### PR TITLE
Show check in information

### DIFF
--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -42,7 +42,7 @@ const Home: NextPage = () => {
             </span>
           </p>
           <p className="text-lg flex gap-2 justify-center">
-            {allowed == undefined || contract == undefined ? (
+            {allowed === undefined || contract === undefined ? (
               <></>
             ) : !allowed ? (
               <span>You are not registered in this batch.</span>

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -2,13 +2,28 @@
 
 import Link from "next/link";
 import type { NextPage } from "next";
+import { useAccount } from "wagmi";
 import { BugAntIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 import { useScaffoldContractRead } from "~~/hooks/scaffold-eth";
 
 const Home: NextPage = () => {
+  const { address } = useAccount();
+
   const { data: checkInCount } = useScaffoldContractRead({
     contractName: "BatchRegistry",
     functionName: "checkedInCounter",
+  });
+
+  const { data: allowed } = useScaffoldContractRead({
+    contractName: "BatchRegistry",
+    functionName: "allowList",
+    args: [address],
+  });
+
+  const { data: contract } = useScaffoldContractRead({
+    contractName: "BatchRegistry",
+    functionName: "yourContractAddress",
+    args: [address],
   });
 
   return (
@@ -20,11 +35,27 @@ const Home: NextPage = () => {
             <span className="block text-4xl font-bold">Batch 2</span>
           </h1>
           <p className="text-center text-lg">Get started by taking a look at your batch GitHub repository.</p>
-          <p className="text-lg flex gap-2 justify-center">
+          <p className="text-lg flex gap-2 mt-8 justify-center">
             <span className="font-bold">
               Checked in builders count:{" "}
               {checkInCount?.toString() ?? <span className="loading loading-spinner loading-sm"></span>}
             </span>
+          </p>
+          <p className="text-lg flex gap-2 justify-center">
+            {allowed == undefined || contract == undefined ? (
+              <></>
+            ) : !allowed ? (
+              <span>You are not registered in this batch.</span>
+            ) : parseInt(contract, 16) === 0 ? (
+              <span>You have not checked in yet. Check in and get your reward!</span>
+            ) : (
+              <span>
+                Your contract address:{" "}
+                <Link href={`https://optimistic.etherscan.io/address/${contract}`} passHref className="link">
+                  {contract}
+                </Link>
+              </span>
+            )}
           </p>
         </div>
 


### PR DESCRIPTION
## Description

Add connected wallet's check in information on home page.
- Doesn't show information on unconnected wallet

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #4_

Your ENS/address: starcastella.eth
